### PR TITLE
Ignore invalid JDK bin paths

### DIFF
--- a/java/jmh/run_jmh_jdk_micros.sh
+++ b/java/jmh/run_jmh_jdk_micros.sh
@@ -204,6 +204,12 @@ benchmark="$benchmark $machine_readable_output_file_opt $format_type_opt"
 jdk="jdk-17.0.1+12"
 jdk_bin_path="./jdks/$jdk/bin/"
 
+if [ ! -d "$jdk_bin_path" ]; then
+    echo "Warning: Could not find JDK bin path: $jdk_bin_path"
+    echo "Warning: Using the java binary automatically selected by the shell."
+    jdk_bin_path=""
+fi
+
 run_benchmarks()
 {
     date


### PR DESCRIPTION
The run_jmh_jdk_micros script assumes that there is a JDK in the
jdks subdirectory. If there is no JDK there, this change instead
makes it display a warning that it will use the default java
command selected by the shell (usually from the PATH). This
makes it easy to test changes to the script without having to
populate the jdks subdirectory.